### PR TITLE
implement print!({},x) and printls -al({:?},x), where x is ModInt

### DIFF
--- a/solve/src/main.rs
+++ b/solve/src/main.rs
@@ -516,7 +516,7 @@ mod modint {
         }
     }
 
-    #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+    #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct ModInt<T, M>(T, M)
     where
         M: Modulus<T>,
@@ -569,6 +569,27 @@ mod modint {
             }
         }
     }
+
+    impl<T, M> std::fmt::Display for  ModInt<T, M>
+    where
+        M: Modulus<T>,
+        T: NumAssignOps + PrimInt + Unsigned + std::fmt::Display,
+    {
+        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(f, "{}", self.value())
+        }
+    }
+
+    impl<T, M> std::fmt::Debug for  ModInt<T, M>
+    where
+        M: Modulus<T>,
+        T: NumAssignOps + PrimInt + Unsigned + std::fmt::Display,
+    {
+        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(f, "{}", self.value())
+        }
+    }
+
     impl<M> ModInt<usize, M>
     where
         M: StaticModulus<usize>,


### PR DESCRIPTION
Title -> implement print!({},x) and print!({:?},x), where x is ModInt 
I implemented Display and Debug for ModInt. 
Sample Code and Output:
```rust
let dp = vec![vec![ModInt::<_, Mod10>::new(0);5];5];
println!("{:?}", dp);
// [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
println!("{:?}", dp[0]);
// [0, 0, 0]
println!("{}", dp[0][0]);
// 0
```